### PR TITLE
Fix readiness check configuration bug and remove unused props

### DIFF
--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -1,8 +1,8 @@
-"""
-Health check routes for ReportRx backend.
-"""
+"""Health check routes for ReportRx backend."""
+
 from fastapi import APIRouter
-from ..models import ErrorResponse
+
+from ..config import settings
 
 router = APIRouter()
 
@@ -24,6 +24,6 @@ async def readiness_check():
     return {
         "status": "ready",
         "checks": {
-            "openai_configured": bool(len(str(getattr(__import__('app.config', fromlist=['settings']), 'settings').openai_api_key)) > 0)
-        }
+            "openai_configured": bool(settings.openai_api_key),
+        },
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
 
   const stepLabels = ['Upload', 'Parse Data', 'AI Analysis', 'Follow-up'];
 
-  const handleFileUpload = (content: string, filename?: string) => {
+  const handleFileUpload = (content: string) => {
     setReportContent(content);
     setCurrentStep(2);
   };
@@ -87,9 +87,8 @@ function App() {
       <Header />
       
       {currentStep > 1 && (
-        <ProgressBar 
+        <ProgressBar
           currentStep={currentStep}
-          totalSteps={4}
           stepLabels={stepLabels}
         />
       )}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { CheckCircle, Circle } from 'lucide-react';
+import { CheckCircle } from 'lucide-react';
 
 interface ProgressBarProps {
   currentStep: number;
-  totalSteps: number;
   stepLabels: string[];
 }
 
-export const ProgressBar: React.FC<ProgressBarProps> = ({ currentStep, totalSteps, stepLabels }) => {
+export const ProgressBar: React.FC<ProgressBarProps> = ({ currentStep, stepLabels }) => {
   return (
     <div className="w-full bg-white border-b border-gray-200 py-6">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- fix readiness endpoint reporting OpenAI configured even when key is missing
- remove unused props and imports from React components

## Testing
- `python -m py_compile backend/app/routes/health.py`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688de3100b2c832a81d5d42ed1757d57