### PR TITLE
Use Vite proxy for backend API requests

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = 'http://127.0.0.1:8000/api/v1';
+// Base URL for API requests. During development, Vite's dev server
+// proxies requests starting with `/api` to the FastAPI backend.
+const API_BASE_URL = '/api/v1';
 
 export interface LabTest {
   name: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,13 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:8000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- route `/api` calls through Vite's dev server to the FastAPI backend
- simplify frontend API client to use relative `/api/v1` base URL

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8291891a4832aab12931b18d6992a